### PR TITLE
Add copying

### DIFF
--- a/DataStructures/DiffDataStructure.py
+++ b/DataStructures/DiffDataStructure.py
@@ -24,3 +24,9 @@ class DiffDataStructure(object):
 		}
 		self.diff = sortedDiff
 		return self.diff
+	
+	def getFiles(self):
+		return self.diff[self.filesKey]
+	
+	def getDirectories(self):
+		return self.diff[self.dirsKey]

--- a/DataStructures/DirectoryInfo.py
+++ b/DataStructures/DirectoryInfo.py
@@ -7,10 +7,17 @@ class DirectoryInfo(object):
     def __init__(self, path, dirs, files):
         #various files that don't need to be considered
         skippedFiles = [".DS_Store"]
+        skippedDirectories = [".fseventsd", '.Spotlight-V100', '.Trashes', '.DocumentRevisions-V100', '.TemporaryItems']
+        
+#         ignoreFileRegex = '._'
 
         self.path = path
-        self.containedDirectories = set(dirs)
-        self.containedFiles = set((f for f in files if f not in skippedFiles))
+        self.containedDirectories = self._skip(dirs, skippedDirectories)
+        self.containedFiles = self._skip(files, skippedFiles)
+
+    def _skip(self, array, skipValues):
+        return set((v for v in array if v not in skipValues))
+        #return set((v for v in array if v not in skipValues and not v.startswith(self.ignoreFileRegex)))
 
     def getPath(self):
         return self.path

--- a/DiffDrives.py
+++ b/DiffDrives.py
@@ -2,17 +2,23 @@ from pprint import pprint
 from os import path
 from sys import argv
 from Factories.CompareTwoDirectoriesEngineFactory import CompareTwoDirectoriesEngineFactory
+from Factories.CopyFilesAndDirectoriesEngineFactory import CopyFilesAndDirectoriesEngineFactory
 from Logging import printSTATUS
 
 def main(pathA, pathB):
 	printSTATUS(f"main called with {pathA}, {pathB}")
 	twoDirComp = CompareTwoDirectoriesEngineFactory.getEngine()
+	copyContents = CopyFilesAndDirectoriesEngineFactory.getEngine()
 
 	#verify paths exist before walking them
 	if path.exists(pathA) and path.exists(pathB):
-		diffSolution = twoDirComp.compare(pathA, pathB)
-		pprint(diffSolution, width=300)
-		return diffSolution	
+		contentsInAButNotB = twoDirComp.compare(pathA, pathB)
+		pprint(contentsInAButNotB, width=300)
+		# userConfirmation = input(f"Would you like to copy all the above files and directories over from {pathA} to {pathB} (y/n): ")
+		# if userConfirmation.lower() == "y":
+		# 	print("COPYING")
+		copyContents.copyFilesAndDirectories(pathA, pathB, contentsInAButNotB)
+		return contentsInAButNotB.getDiff()	
 	return -1
 
 if __name__ == "__main__":

--- a/DiffDrives.py
+++ b/DiffDrives.py
@@ -32,8 +32,12 @@ if __name__ == "__main__":
 	if len(argv) != 3:
 		print("usage: python3 DiffDrives.py /path/to/dir/1 /path/to/dir/2")
 		exit(-1)
+	
+	# clean up input (make sure both dirs are terminated with a separator)
+	source = path.join(argv[1], "")
+	dest = path.join(argv[2], "")
 
 	#pass in the two paths to be diffed
-	returnCode = main(argv[1], argv[2])
+	returnCode = main(source, dest)
 	exit(returnCode)
 	 

--- a/DiffDrives.py
+++ b/DiffDrives.py
@@ -15,7 +15,7 @@ def main(pathA, pathB):
 	# compare the directories
 	twoDirComp = CompareTwoDirectoriesEngineFactory.getEngine()
 	contentsInAButNotB = twoDirComp.compare(pathA, pathB)
-	pprint(contentsInAButNotB, width=300)
+	pprint(contentsInAButNotB.getDiff(), width=300)
 
 	# optionally copy the directories
 	userConfirmation = input(f"Would you like to copy all the above files and directories over from {pathA} to {pathB} (y/n): ")

--- a/DiffDrives.py
+++ b/DiffDrives.py
@@ -7,19 +7,26 @@ from Logging import printSTATUS
 
 def main(pathA, pathB):
 	printSTATUS(f"main called with {pathA}, {pathB}")
-	twoDirComp = CompareTwoDirectoriesEngineFactory.getEngine()
-	copyContents = CopyFilesAndDirectoriesEngineFactory.getEngine()
 
-	#verify paths exist before walking them
-	if path.exists(pathA) and path.exists(pathB):
-		contentsInAButNotB = twoDirComp.compare(pathA, pathB)
-		pprint(contentsInAButNotB, width=300)
-		# userConfirmation = input(f"Would you like to copy all the above files and directories over from {pathA} to {pathB} (y/n): ")
-		# if userConfirmation.lower() == "y":
-		# 	print("COPYING")
+	# verify paths exist before walking them
+	if not path.exists(pathA) or not path.exists(pathB):
+		return -1
+
+	# compare the directories
+	twoDirComp = CompareTwoDirectoriesEngineFactory.getEngine()
+	contentsInAButNotB = twoDirComp.compare(pathA, pathB)
+	pprint(contentsInAButNotB, width=300)
+
+	# optionally copy the directories
+	userConfirmation = input(f"Would you like to copy all the above files and directories over from {pathA} to {pathB} (y/n): ")
+	if userConfirmation.lower() == "y":
+		print("COPYING")
+		copyContents = CopyFilesAndDirectoriesEngineFactory.getEngine()
 		copyContents.copyFilesAndDirectories(pathA, pathB, contentsInAButNotB)
-		return contentsInAButNotB.getDiff()	
-	return -1
+	
+	# return success
+	return 0	
+	
 
 if __name__ == "__main__":
 	if len(argv) != 3:

--- a/Engines/CompareTwoDirectories.py
+++ b/Engines/CompareTwoDirectories.py
@@ -9,9 +9,9 @@ class CompareTwoDirectories(object):
 	def compare(self, pathA, pathB):
 		self.dataStorage = DiffDataStructure()
 		self._compareRecurse(pathA, pathB)
-		return self.dataStorage.getDiff()
+		return self.dataStorage
 	
-	def pathFrom(self, pathStart, nextLevel):
+	def _pathFrom(self, pathStart, nextLevel):
 		return pathStart + sep + nextLevel
 
 	def _getResultsOfSetOperations(self, directoryInfoA, directoryInfoB):
@@ -35,8 +35,8 @@ class CompareTwoDirectories(object):
 
 		# add the path to all files and dirs that were missing
 		pathB = directoryInfoB.getPath()
-		dirExtension = [self.pathFrom(pathB, x) for x in dirsInAbutNotB]
-		fileExtension = [self.pathFrom(pathB, x) for x in filesInAbutNotInB] 
+		dirExtension = [self._pathFrom(pathB, x) for x in dirsInAbutNotB]
+		fileExtension = [self._pathFrom(pathB, x) for x in filesInAbutNotInB] 
 
 		# track all the missing files and dirs
 		self.dataStorage.trackDirs(dirExtension)
@@ -56,12 +56,8 @@ class CompareTwoDirectories(object):
 			return None
 
 		nextCandidates = self._trackDifferencesAndCalculateNextCandidates(directoryInfoA, directoryInfoB)
-
-		# XXX paranoid for now - will remove if this doesn't trigger the next time I use it
-		assert(directoryInfoA.getPath() == pathA)
-		assert(directoryInfoB.getPath() == pathB)
 		
 		for childofBoth in nextCandidates:
-			newPathA = self.pathFrom(pathA, childofBoth)
-			newPathB = self.pathFrom(pathB, childofBoth)
+			newPathA = self._pathFrom(pathA, childofBoth)
+			newPathB = self._pathFrom(pathB, childofBoth)
 			self._compareRecurse(newPathA, newPathB)

--- a/Engines/CompareTwoDirectories.py
+++ b/Engines/CompareTwoDirectories.py
@@ -1,4 +1,4 @@
-from os import sep
+from os import path
 from DataStructures.DiffDataStructure import DiffDataStructure
 from Logging import printSTATUS, printDEBUG
 
@@ -10,9 +10,6 @@ class CompareTwoDirectories(object):
 		self.dataStorage = DiffDataStructure()
 		self._compareRecurse(pathA, pathB)
 		return self.dataStorage
-	
-	def _pathFrom(self, pathStart, nextLevel):
-		return pathStart + sep + nextLevel
 
 	def _getResultsOfSetOperations(self, directoryInfoA, directoryInfoB):
 		dirsA, filesA = directoryInfoA.getDirs(), directoryInfoA.getFiles()
@@ -35,8 +32,8 @@ class CompareTwoDirectories(object):
 
 		# add the path to all files and dirs that were missing
 		pathB = directoryInfoB.getPath()
-		dirExtension = [self._pathFrom(pathB, x) for x in dirsInAbutNotB]
-		fileExtension = [self._pathFrom(pathB, x) for x in filesInAbutNotInB] 
+		dirExtension = [path.join(pathB, x) for x in dirsInAbutNotB]
+		fileExtension = [path.join(pathB, x) for x in filesInAbutNotInB] 
 
 		# track all the missing files and dirs
 		self.dataStorage.trackDirs(dirExtension)
@@ -58,6 +55,6 @@ class CompareTwoDirectories(object):
 		nextCandidates = self._trackDifferencesAndCalculateNextCandidates(directoryInfoA, directoryInfoB)
 		
 		for childofBoth in nextCandidates:
-			newPathA = self._pathFrom(pathA, childofBoth)
-			newPathB = self._pathFrom(pathB, childofBoth)
+			newPathA = path.join(pathA, childofBoth)
+			newPathB = path.join(pathB, childofBoth)
 			self._compareRecurse(newPathA, newPathB)

--- a/Engines/CopyFilesAndDirectories.py
+++ b/Engines/CopyFilesAndDirectories.py
@@ -1,0 +1,22 @@
+
+
+# copy2 will copy metadata of the file
+from shutil import copy2, copytree
+from os import path
+
+class CopyFilesAndDirectories:
+
+    def _getSourcePath(self, sourcePath, pathA, pathB):
+        return sourcePath.replace(pathB, pathA)
+    
+    def copyFilesAndDirectories(self, pathA, pathB, fileAndDirectoryPaths):
+        for destinationFilePath in fileAndDirectoryPaths.getFiles():
+            sourceFilePath = self._getSourcePath(destinationFilePath, pathA, pathB)
+            print(f"copying {sourceFilePath} to {destinationFilePath}")
+            copy2(sourceFilePath, destinationFilePath)
+        
+        for destinationDirectoryPath in fileAndDirectoryPaths.getDirectories():
+            sourceDirectoryPath = self._getSourcePath(destinationDirectoryPath, pathA, pathB)
+            print(f"copying {sourceDirectoryPath} to {destinationDirectoryPath}")
+            copytree(sourceDirectoryPath, destinationDirectoryPath, copy_function=copy2)
+

--- a/Engines/CopyFilesAndDirectories.py
+++ b/Engines/CopyFilesAndDirectories.py
@@ -1,5 +1,3 @@
-
-
 # copy2 will copy metadata of the file
 from shutil import copy2, copytree
 from os import path

--- a/Factories/CopyFilesAndDirectoriesEngineFactory.py
+++ b/Factories/CopyFilesAndDirectoriesEngineFactory.py
@@ -1,0 +1,6 @@
+from Engines.CopyFilesAndDirectories import CopyFilesAndDirectories
+
+class CopyFilesAndDirectoriesEngineFactory(object):
+    @staticmethod
+    def getEngine():
+        return CopyFilesAndDirectories()

--- a/TestConfigParser/ConfigInterpreter.py
+++ b/TestConfigParser/ConfigInterpreter.py
@@ -1,4 +1,4 @@
-from os import sep
+from os import path
 
 from Constants import baseDir, targetA, targetB
 
@@ -21,7 +21,7 @@ class ConfigInterpreter(object):
     
     def _setupTestingData(self, testCaseName, testCaseSetup):
         for setupDir in [targetA, targetB]:
-            context = baseDir + sep + testCaseName + sep + setupDir
+            context = path.join(baseDir, testCaseName, setupDir)
             currentSetup = testCaseSetup[setupDir]
             self._handleDirectory(context, currentSetup)
 
@@ -42,4 +42,4 @@ class ConfigInterpreter(object):
         # if there are directories in the directory, recurse and create them too
         if self.dirsKey in directory:
             for subDirName, subDirContents in directory[self.dirsKey].items():
-                self._handleDirectory(context + sep + subDirName, subDirContents)
+                self._handleDirectory(path.join(context, subDirName), subDirContents)

--- a/TestConfigParser/TestCaseConfigParser.py
+++ b/TestConfigParser/TestCaseConfigParser.py
@@ -1,4 +1,4 @@
-from os import sep
+from os import path
 from TestConfigParser.Constants import baseDir
 class TestCaseConfigParser(object):
 	def __init__(self, parsedYaml):
@@ -31,6 +31,6 @@ class TestCaseConfigParser(object):
 		for k, v in expectedOutput.items():
 			newV = []
 			for entry in v:
-				newV.append(baseDir + sep + testCaseName + sep + entry)
+				newV.append(path.join(baseDir, testCaseName, entry))
 			expectedOutputAdjusted[k] = sorted(newV)
 		return expectedOutputAdjusted

--- a/TestConfigParser/TestDataBuilder.py
+++ b/TestConfigParser/TestDataBuilder.py
@@ -1,4 +1,4 @@
-from os import path, makedirs, utime, sep
+from os import path, makedirs, utime
 # object that handles interacting with the file system
 class TestDataBuilder(object):
     # implementation of `touch` from https://stackoverflow.com/a/12654798/7520564
@@ -8,7 +8,7 @@ class TestDataBuilder(object):
 
     def createFiles(self, context, filesToCreate):
         for f in filesToCreate:
-            filePath = context + sep + f
+            filePath = path.join(context, f)
             if not path.exists(filePath):
                 print(f"FILE: {filePath}")
                 self._touch(filePath)

--- a/archived/DiffDrives_old.py
+++ b/archived/DiffDrives_old.py
@@ -43,7 +43,7 @@ def getPath(nameDirsFilesTuple):
 	return nameDirsFilesTuple[0]
 
 def getDirs(nameDirsFilesTuple):
-	return nameDirsFilesTuple[1]
+	return [f for f in nameDirsFilesTuple[1] if f not in ['.DocumentRevisions-V100']]
 
 def getFiles(nameDirsFilesTuple):
 	return [f for f in nameDirsFilesTuple[2] if f not in skippedFiles]

--- a/test_DirectoryAndFile.py
+++ b/test_DirectoryAndFile.py
@@ -7,14 +7,42 @@ Test existing tests (like SameDirectoryStructureFlat) with each of the operands 
 from TestConfigParser.YamlReader import YamlReader
 from TestConfigParser.Constants import baseDir, targetA, targetB
 from TestConfigParser.TestCaseConfigParser import TestCaseConfigParser
-from os import sep
-
+from Factories.CompareTwoDirectoriesEngineFactory import CompareTwoDirectoriesEngineFactory
+from Factories.CopyFilesAndDirectoriesEngineFactory import CopyFilesAndDirectoriesEngineFactory
+from DataStructures.DiffDataStructure import DiffDataStructure
+from os import path
+	
 parsedYaml = YamlReader().fetchYaml("configTesting.yml")
 testCaseConfigParser = TestCaseConfigParser(parsedYaml)
 
 @pytest.mark.parametrize("directory, expected_output, testcase_num", testCaseConfigParser.getTestCases())
-def test_eval(directory, expected_output, testcase_num):
-	basePath = baseDir + sep + directory
+def test_compare(directory, expected_output, testcase_num):
+	basePath = path.join(baseDir, directory)
+	pathA = path.join(basePath, targetA)
+	pathB = path.join(basePath, targetB)
 	print(basePath, expected_output, testcase_num)
-	result = main(basePath + sep + targetA, basePath + sep + targetB)
-	assert(result == expected_output)
+
+	twoDirComp = CompareTwoDirectoriesEngineFactory.getEngine()
+	contentsInAButNotB = twoDirComp.compare(pathA, pathB)
+
+	assert(contentsInAButNotB.getDiff() == expected_output)
+
+@pytest.mark.parametrize("directory, expected_output, testcase_num", testCaseConfigParser.getTestCases())
+def test_copy(directory, expected_output, testcase_num):
+	basePath = path.join(baseDir, directory)
+	pathA = path.join(basePath, targetA)
+	pathB = path.join(basePath, targetB)
+	print(basePath, expected_output, testcase_num)
+
+	twoDirComp = CompareTwoDirectoriesEngineFactory.getEngine()
+	contentsInAButNotB = twoDirComp.compare(pathA, pathB)
+
+	copyContents = CopyFilesAndDirectoriesEngineFactory.getEngine()
+	copyContents.copyFilesAndDirectories(pathA, pathB, contentsInAButNotB)
+
+	twoDirComp_afterCopy = CompareTwoDirectoriesEngineFactory.getEngine()
+	contentsInAButNotB_afterCopy = twoDirComp.compare(pathA, pathB)
+
+	emptyDiff = DiffDataStructure()
+
+	assert(contentsInAButNotB_afterCopy.getDiff() == emptyDiff.getDiff())


### PR DESCRIPTION
Adds the ability to copy the files and directories that differ between the two compared directories. Currently that is activated by answering `y` to the question presented to the user after the comparison completes.

Future enhancement would be adding multiprocessing consumers (not multithreading, cause there's a thread lock in python) and a queue of files/directories that need copying.